### PR TITLE
Update animal-sniffer enforcer-rule artifact to 1.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <!-- *************** -->
     <!-- Others versions -->
     <!-- *************** -->
-    <version.animal-sniffer.enforcer-rule>1.15</version.animal-sniffer.enforcer-rule>
+    <version.animal-sniffer.enforcer-rule>1.18</version.animal-sniffer.enforcer-rule>
     <version.wagon>2.7</version.wagon>
     <!-- PAR-193 : performances boost workaround -->
     <version.plexus-utils>3.0.18</version.plexus-utils>


### PR DESCRIPTION
Currently, the animal sniffer enforcer-rule doesn't support JDK 1.8 classes versions. This PR will update the artifact version to make it supported.