### PR TITLE
Enable Full stack trace display in Unit Tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -896,6 +896,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${version.surefire.plugin}</version>
           <configuration>
+            <trimStackTrace>false</trimStackTrace>
             <systemPropertyVariables>
               <!-- To avoid conflicts on CI server - PAR-192 -->
               <!-- There is an incompatibility with Byteman - used in social -->


### PR DESCRIPTION
By default, the uncaught exceptions in JUnit Test methods are trimmed and doesn't display by default the full stack Trace.
This makes tests debugging harder and especially when not reproducing errors only on CI.
For more information about htis options, see :
* https://www.igorkromin.net/index.php/2017/08/17/how-to-enable-the-full-stack-trace-in-mavens-surefire-plugin-for-junit-testing/
* http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#trimStackTrace