### PR TITLE
Update maven-jibx-plugin to version 1.3.1 to fix BCEL-173

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <version.jdepend.plugin>2.0</version.jdepend.plugin>
     <!-- PAR-222 : jdocbook 2.3.6+ has a perf issue. See MPJDOCBOOK-84 -->
     <version.jdocbook.plugin>2.3.5</version.jdocbook.plugin>
-    <version.jibx.plugin>1.2.6</version.jibx.plugin>
+    <version.jibx.plugin>1.3.1</version.jibx.plugin>
     <version.jmeter.plugin>1.10.1</version.jmeter.plugin>
     <version.jodconverter.plugin>2.2.1</version.jodconverter.plugin>
     <version.jstools.plugin>0.7</version.jstools.plugin>


### PR DESCRIPTION
A workaround has been added in some POM files to fix bug https://issues.apache.org/jira/browse/BCEL-173.
By upgrading the plugin version to 1.3.1, this workaround will no more be useful.