### PR TITLE
Update extra enforcer rules version from 1.1 to 1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <jdk.min.version>${maven.compiler.source}</jdk.min.version>
     <exo.release.enforce.requirePluginVersions.banSnapshots>true</exo.release.enforce.requirePluginVersions.banSnapshots>
     <!-- Extra enforcer rules -->
-    <extra-enforcer-rules.version>1.1</extra-enforcer-rules.version>
+    <extra-enforcer-rules.version>1.3</extra-enforcer-rules.version>
     <!-- gmaven-plugin -->
     <gmaven-plugin.providerSelection>2.0</gmaven-plugin.providerSelection>
     <!-- maven-gpg-plugin -->


### PR DESCRIPTION
I need this fix to be able to update version of bouncycastle dependencies.
Without this fix, and with bouncy castle update, and error is thrown during the run of the enforcer :

> [ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M3:enforce (enforce-bytecode-version) on project plf-dependencies: Execution enforce-bytecode-version of goal org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M3:enforce failed.: NullPointerException -> [Help 1]
> org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M3:enforce (enforce-bytecode-version) on project plf-dependencies: Execution enforce-bytecode-version of goal org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M3:enforce failed.
>     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:213)
>     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:154)
> ...
> Caused by: java.lang.NullPointerException
>     at org.apache.maven.plugins.enforcer.EnforceBytecodeVersion.isBadArtifact (EnforceBytecodeVersion.java:323)
>     at org.apache.maven.plugins.enforcer.EnforceBytecodeVersion.checkDependencies (EnforceBytecodeVersion.java:235)
>     at org.apache.maven.plugins.enforcer.EnforceBytecodeVersion.handleArtifacts (EnforceBytecodeVersion.java:160)
>     at org.apache.maven.plugins.enforcer.AbstractResolveDependencies.execute (AbstractResolveDependencies.java:77)
> 

I found information in this issue : https://issues.apache.org/jira/browse/MENFORCER-367
The update of extra enforcer rules to 1.3 fix the problem