### PR TITLE
Update Maven plugin dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <version.clirr.plugin>2.8-eXo01</version.clirr.plugin>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.copy.plugin>0.2.5</version.copy.plugin>
-    <version.dependency.plugin>3.2.0</version.dependency.plugin>
+    <version.dependency.plugin>3.3.0</version.dependency.plugin>
     <version.deploy.plugin>2.8.2</version.deploy.plugin>
     <version.docck.plugin>1.1</version.docck.plugin>
     <version.docbkx.plugin>2.0.16</version.docbkx.plugin>


### PR DESCRIPTION
Before this commit, when using mvn dependency:tree with -Dverbose option it hangs for a while.
This change update the version to 3.3.0 which fix the problem