### PR TITLE
feat: upgrade maven plugin to use JDK 17 - EXO-58815

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <version.jacoco.plugin>0.8.7</version.jacoco.plugin>
     <version.jar.plugin>2.6</version.jar.plugin>
     <version.javacc.plugin>2.6</version.javacc.plugin>
-    <version.javadoc.plugin>2.10.3</version.javadoc.plugin>
+    <version.javadoc.plugin>3.4.1</version.javadoc.plugin>
     <version.javancss.plugin>2.1</version.javancss.plugin>
     <version.jaxb2.plugin>2.2</version.jaxb2.plugin>
     <!-- PAR-362: weaves .class files with AspectJ aspects available in classpath (binary weaving) -->
@@ -182,12 +182,12 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <version.taglist.plugin>2.4</version.taglist.plugin>
     <version.tomcat7.plugin>2.2</version.tomcat7.plugin>
     <version.versions.plugin>2.2</version.versions.plugin>
-    <version.war.plugin>2.6</version.war.plugin>
+    <version.war.plugin>3.3.2</version.war.plugin>
     <version.wikbook.plugin>0.9.45</version.wikbook.plugin>
     <version.xml.plugin>1.0</version.xml.plugin>
     <version.yuicompressor.plugin>0.7.1</version.yuicompressor.plugin>
     <version.owasp.dependency-check-maven.plugin>3.1.2</version.owasp.dependency-check-maven.plugin>
-    <org.lombok.plugin.version>1.18.0.0</org.lombok.plugin.version>
+    <org.lombok.plugin.version>1.18.20.0</org.lombok.plugin.version>
     <com.github.eirslett.frontend.version>1.12.1</com.github.eirslett.frontend.version>
     <io.openapitools.swagger.version>2.1.6</io.openapitools.swagger.version>
     <node.version>v16.0.0</node.version>


### PR DESCRIPTION
upgrade maven plugins to use JDK 17
javadoc plugin : 3.4.1
lombok version: 1.18.20.0
maven-war-plugin: 3.3.2