### PR TITLE
feat: upgrade maven plugin to use JDK 17 - EXO-58815 - Meeds-io/MIPs#26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <version.sonar-maven-report.plugin>0.1</version.sonar-maven-report.plugin>
     <version.sortpom.plugin>2.3.1</version.sortpom.plugin>
     <version.source.plugin>3.0.0</version.source.plugin>
-    <version.surefire.plugin>2.19.1</version.surefire.plugin>
+    <version.surefire.plugin>2.22.2</version.surefire.plugin>
     <version.taglist.plugin>2.4</version.taglist.plugin>
     <version.tomcat7.plugin>2.2</version.tomcat7.plugin>
     <version.versions.plugin>2.2</version.versions.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <version.jacoco.plugin>0.8.7</version.jacoco.plugin>
     <version.jar.plugin>2.6</version.jar.plugin>
     <version.javacc.plugin>2.6</version.javacc.plugin>
-    <version.javadoc.plugin>2.10.3</version.javadoc.plugin>
+    <version.javadoc.plugin>3.4.1</version.javadoc.plugin>
     <version.javancss.plugin>2.1</version.javancss.plugin>
     <version.jaxb2.plugin>2.2</version.jaxb2.plugin>
     <!-- PAR-362: weaves .class files with AspectJ aspects available in classpath (binary weaving) -->
@@ -182,12 +182,12 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <version.taglist.plugin>2.4</version.taglist.plugin>
     <version.tomcat7.plugin>2.2</version.tomcat7.plugin>
     <version.versions.plugin>2.2</version.versions.plugin>
-    <version.war.plugin>2.6</version.war.plugin>
+    <version.war.plugin>3.3.2</version.war.plugin>
     <version.wikbook.plugin>0.9.45</version.wikbook.plugin>
     <version.xml.plugin>1.0</version.xml.plugin>
     <version.yuicompressor.plugin>0.7.1</version.yuicompressor.plugin>
     <version.owasp.dependency-check-maven.plugin>3.1.2</version.owasp.dependency-check-maven.plugin>
-    <org.lombok.plugin.version>1.18.0.0</org.lombok.plugin.version>
+    <org.lombok.plugin.version>1.18.20.0</org.lombok.plugin.version>
     <com.github.eirslett.frontend.version>1.12.1</com.github.eirslett.frontend.version>
     <io.openapitools.swagger.version>2.1.6</io.openapitools.swagger.version>
     <node.version>v16.0.0</node.version>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <version.eclipse.plugin>2.10</version.eclipse.plugin>
     <version.ear.plugin>2.10.1</version.ear.plugin>
     <version.ejb.plugin>2.5.1</version.ejb.plugin>
-    <version.enforcer.plugin>3.0.0-M3</version.enforcer.plugin>
+    <version.enforcer.plugin>3.1.0</version.enforcer.plugin>
     <version.exec.plugin>1.4.0</version.exec.plugin>
     <version.exobuild.plugin>1.2.2</version.exobuild.plugin>
     <version.exopc.plugin>1.0.5</version.exopc.plugin>
@@ -149,7 +149,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <version.jaxb2.plugin>2.2</version.jaxb2.plugin>
     <!-- PAR-362: weaves .class files with AspectJ aspects available in classpath (binary weaving) -->
     <version.jcabi.plugin>0.14</version.jcabi.plugin>
-    <version.jcabi.aspectj.dependencies.plugin>1.9.6</version.jcabi.aspectj.dependencies.plugin>
+    <version.jcabi.aspectj.dependencies.plugin>1.9.9.1</version.jcabi.aspectj.dependencies.plugin>
     <version.jdepend.plugin>2.0</version.jdepend.plugin>
     <!-- PAR-222 : jdocbook 2.3.6+ has a perf issue. See MPJDOCBOOK-84 -->
     <version.jdocbook.plugin>2.3.5</version.jdocbook.plugin>
@@ -173,7 +173,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <version.remote-resources.plugin.version>1.5</version.remote-resources.plugin.version>
     <version.resources.plugin>3.2.0</version.resources.plugin>
     <version.selenium.plugin>2.3</version.selenium.plugin>
-    <version.shade.plugin>3.2.4</version.shade.plugin>
+    <version.shade.plugin>3.4.1</version.shade.plugin>
     <version.site.plugin>3.4</version.site.plugin>
     <version.sonar-maven-report.plugin>0.1</version.sonar-maven-report.plugin>
     <version.sortpom.plugin>2.3.1</version.sortpom.plugin>
@@ -212,8 +212,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <!-- maven-clirr-plugin -->
     <textOutputFile>${project.build.directory}/clirr-report.txt</textOutputFile>
     <!-- maven-compiler-plugin -->
-    <maven.compiler.target>11</maven.compiler.target>
-    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
     <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
     <maven.compiler.optimize>true</maven.compiler.optimize>
@@ -224,7 +224,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <jdk.min.version>${maven.compiler.source}</jdk.min.version>
     <exo.release.enforce.requirePluginVersions.banSnapshots>true</exo.release.enforce.requirePluginVersions.banSnapshots>
     <!-- Extra enforcer rules -->
-    <extra-enforcer-rules.version>1.3</extra-enforcer-rules.version>
+    <extra-enforcer-rules.version>1.6.1</extra-enforcer-rules.version>
     <!-- gmaven-plugin -->
     <gmaven-plugin.providerSelection>2.0</gmaven-plugin.providerSelection>
     <!-- maven-gpg-plugin -->


### PR DESCRIPTION
upgrade maven plugins to use JDK 17
javadoc plugin : 3.4.1
lombok version: 1.18.20.0
maven-war-plugin: 3.3.2