### PR TITLE
TASK-64565: avoid gpg signing prompt with gpg 2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1399,6 +1399,12 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 <goals>
                   <goal>sign</goal>
                 </goals>
+                <configuration>
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                </configuration>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
Before this change, the gpg 2.x signature failed. (It is part of new OS version of our CI images). 
This PR can't be merged before moving the builds with the new docker ci image version. The concerned versions are 1.5.x 
