### PR TITLE
TASK-64565: avoid gpg signing prompt with gpg 2.x and update version to match with Meeds's

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1399,6 +1399,12 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 <goals>
                   <goal>sign</goal>
                 </goals>
+                <configuration>
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.exoplatform</groupId>
   <artifactId>maven-parent-pom</artifactId>
-  <version>25-meed-SNAPSHOT</version>
+  <version>26-meed-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>eXo PLF:: Parent POM</name>
   <description>Provides default project configuration for eXo projects</description>


### PR DESCRIPTION
- Before this change, the gpg 2.x signature failed. (It is part of new OS version of our CI images).

This PR can't be merged before moving the builds with the new docker ci image version. The concerned versions are 1.5.x

- An update for tha version is proposed to match with Meeds 1.5.x's
