### PR TITLE
fix: Update to jdk21 - EXO-71474 - meeds-io/MIPs#91

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <version.xml.plugin>1.0</version.xml.plugin>
     <version.owasp.dependency-check-maven.plugin>3.2.0</version.owasp.dependency-check-maven.plugin>
     <org.lombok.plugin.version>1.18.20.0</org.lombok.plugin.version>
+    <org.lombok.version>1.18.30</org.lombok.version>
     <com.github.eirslett.frontend.version>1.15.0</com.github.eirslett.frontend.version>
     <io.openapitools.swagger.version>2.1.6</io.openapitools.swagger.version>
     <node.version>v16.0.0</node.version>
@@ -876,6 +877,13 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok-maven-plugin</artifactId>
         <version>${org.lombok.plugin.version}</version>
+        <dependencies>
+	    <dependency>
+		<groupId>org.projectlombok</groupId>
+		<artifactId>lombok</artifactId>
+		<version>${org.lombok.version}</version>
+	    </dependency>
+	</dependencies>
         <executions>
           <execution>
             <phase>generate-sources</phase>


### PR DESCRIPTION
Before this fix, we use lombok-maven-plugin version 1.18.20.0 which use lombok 1.18.20 which is not compatible with jdk21. This fix is a workaround waiting this pr to be merged : https://github.com/awhitford/lombok.maven/pull/180 and a new artifact released

Resolves meeds-io/MIPs#91

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
