### PR TITLE
feat: Replace Jcabi Plugin by AspectJ Maven Plugin - Meeds-io/meeds#2417

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <version.assembly.plugin>3.6.0</version.assembly.plugin>
     <version.buildhelper.plugin>1.10</version.buildhelper.plugin>
     <version.buildnumber.plugin>1.4</version.buildnumber.plugin>
+    <version.bsc.processor.plugin>5.1</version.bsc.processor.plugin>
     <version.clean.plugin>3.3.2</version.clean.plugin>
     <version.changes.plugin>2.12.1</version.changes.plugin>
     <version.compiler.plugin>3.11.0</version.compiler.plugin>
@@ -123,8 +124,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <version.jacoco.plugin>0.8.11</version.jacoco.plugin>
     <version.jar.plugin>3.3.0</version.jar.plugin>
     <version.javadoc.plugin>3.6.3</version.javadoc.plugin>
-    <version.jcabi.plugin>0.17.0</version.jcabi.plugin>
-    <version.jcabi.aspectj.dependencies.plugin>1.9.20.1</version.jcabi.aspectj.dependencies.plugin>
+    <plugin.aspectj.version>1.15.0</plugin.aspectj.version>
+    <org.aspectj.version>1.9.22.1</org.aspectj.version>
     <!-- PAR-222 : jdocbook 2.3.6+ has a perf issue. See MPJDOCBOOK-84 -->
     <version.jdocbook.plugin>2.3.5</version.jdocbook.plugin>
     <version.jibx.plugin>1.3.1</version.jibx.plugin>
@@ -152,7 +153,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <version.xml.plugin>1.0</version.xml.plugin>
     <version.owasp.dependency-check-maven.plugin>3.2.0</version.owasp.dependency-check-maven.plugin>
     <org.lombok.plugin.version>1.18.20.0</org.lombok.plugin.version>
-    <org.lombok.version>1.18.30</org.lombok.version>
+    <org.lombok.version>1.18.34</org.lombok.version>
     <com.github.eirslett.frontend.version>1.15.0</com.github.eirslett.frontend.version>
     <io.openapitools.swagger.version>2.1.6</io.openapitools.swagger.version>
     <node.version>v16.0.0</node.version>
@@ -183,7 +184,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <!-- maven-dependency-plugin -->
     <repoUrl>${exo.public.repo.url}</repoUrl>
     <!-- maven-enforcer-plugin -->
-    <maven.min.version>3.6.0</maven.min.version>
+    <maven.min.version>3.9.0</maven.min.version>
     <jdk.min.version>${maven.compiler.source}</jdk.min.version>
     <exo.release.enforce.requirePluginVersions.banSnapshots>true</exo.release.enforce.requirePluginVersions.banSnapshots>
     <!-- Extra enforcer rules -->
@@ -278,6 +279,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             <!-- Allow to activate/deactivate the recompression of zip files -->
             <recompressZippedFiles>${maven.assembly.recompressZippedFiles}</recompressZippedFiles>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.bsc.maven</groupId>
+          <artifactId>maven-processor-plugin</artifactId>
+          <version>${version.bsc.processor.plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -490,48 +496,31 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           </configuration>
         </plugin>
         <plugin>
-          <groupId>com.jcabi</groupId>
-          <artifactId>jcabi-maven-plugin</artifactId>
-          <version>${version.jcabi.plugin}</version>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>aspectj-maven-plugin</artifactId>
+          <version>${plugin.aspectj.version}</version>
+          <configuration>
+            <source>${maven.compiler.source}</source>
+            <target>${maven.compiler.target}</target>
+            <complianceLevel>${maven.compiler.target}</complianceLevel>
+            <encoding>${project.build.sourceEncoding}</encoding>
+            <showWeaveInfo>true</showWeaveInfo>
+            <verbose>true</verbose>
+            <Xlint>warning</Xlint>
+            <forceAjcCompile>true</forceAjcCompile>
+            <sources />
+            <weaveDirectories>
+              <weaveDirectory>${project.build.directory}/classes</weaveDirectory>
+            </weaveDirectories>
+          </configuration>
           <executions>
             <execution>
-              <id>weave-classes</id>
               <phase>process-classes</phase>
               <goals>
-                <goal>ajc</goal>
+                <goal>compile</goal>
               </goals>
-              <configuration>
-                <classesDirectory>${project.build.outputDirectory}</classesDirectory>
-              </configuration>
-            </execution>
-            <execution>
-              <id>weave-test-classes</id>
-              <phase>process-test-classes</phase>
-              <goals>
-                <goal>ajc</goal>
-              </goals>
-              <configuration>
-                <classesDirectory>${project.build.testOutputDirectory}</classesDirectory>
-              </configuration>
             </execution>
           </executions>
-          <dependencies>
-            <dependency>
-                <groupId>org.aspectj</groupId>
-                <artifactId>aspectjtools</artifactId>
-                <version>${version.jcabi.aspectj.dependencies.plugin}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.aspectj</groupId>
-                <artifactId>aspectjrt</artifactId>
-                <version>${version.jcabi.aspectj.dependencies.plugin}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.aspectj</groupId>
-                <artifactId>aspectjweaver</artifactId>
-                <version>${version.jcabi.aspectj.dependencies.plugin}</version>
-            </dependency>
-        </dependencies>
         </plugin>
         <plugin>
           <groupId>com.github.eirslett</groupId>
@@ -893,22 +882,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>test-jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>com.jcabi</groupId>
-        <artifactId>jcabi-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>
@@ -1661,6 +1634,74 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           <url>https://repository.exoplatform.org/public</url>
         </pluginRepository>
       </pluginRepositories>
+    </profile>
+    <profile>
+      <activation>
+        <property>
+          <name>packaging</name>
+          <value>jar</value>
+        </property>
+        <file>
+          <missing>src/main/resources/no-aop</missing>
+        </file>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.aspectj</groupId>
+          <artifactId>aspectjtools</artifactId>
+          <version>${org.aspectj.version}</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.aspectj</groupId>
+          <artifactId>aspectjrt</artifactId>
+          <version>${org.aspectj.version}</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.aspectj</groupId>
+          <artifactId>aspectjweaver</artifactId>
+          <version>${org.aspectj.version}</version>
+          <scope>provided</scope>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>aspectj-maven-plugin</artifactId>
+            <dependencies>
+              <dependency>
+                <groupId>org.aspectj</groupId>
+                <artifactId>aspectjtools</artifactId>
+                <version>${org.aspectj.version}</version>
+              </dependency>
+              <dependency>
+                <groupId>org.aspectj</groupId>
+                <artifactId>aspectjrt</artifactId>
+                <version>${org.aspectj.version}</version>
+              </dependency>
+              <dependency>
+                <groupId>org.aspectj</groupId>
+                <artifactId>aspectjweaver</artifactId>
+                <version>${org.aspectj.version}</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>test-jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
This change will delete usage of Jcabi Maven plugin to be replaced by AspectJ maven plugin for AspectJ annotation processing in compilation time. At the same time, this change will make the `tests` jar generation made only in modules with `packaging: jar` (same thing for aspectJ execution) to enhance build time, using a new `Maven 3.9` feature which allows to activate a profile by packaging type.