### PR TITLE
fix: Update swagger configuration in order to list Jaxrs and Spring services - meeds-io/meeds#3557

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <org.lombok.version>1.18.34</org.lombok.version>
     <com.github.eirslett.frontend.version>1.15.0</com.github.eirslett.frontend.version>
     <io.openapitools.swagger.version>2.1.6</io.openapitools.swagger.version>
+    <io.swagger.version>2.2.35</io.swagger.version>
     <node.version>v16.0.0</node.version>
     <npm.version>7.11.2</npm.version>
     <!-- *************** -->
@@ -567,6 +568,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           </executions>
         </plugin>
         <plugin>
+          <!-- old plugin to generate OpenAPI documentation - will be removed after modifications in modules -->
           <groupId>io.openapitools.swagger</groupId>
           <artifactId>swagger-maven-plugin</artifactId>
           <version>${io.openapitools.swagger.version}</version>
@@ -596,6 +598,65 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               <version>4.0.1</version>
             </dependency>
           </dependencies>
+        </plugin>
+        <plugin>
+          <!-- plugin to generate OpenAPI documentation for JAXRS REST Services -->
+          <groupId>io.swagger.core.v3</groupId>
+          <artifactId>swagger-maven-plugin</artifactId>
+          <version>${io.swagger.version}</version>
+          <dependencies>
+            <dependency>
+              <groupId>io.swagger.core.v3</groupId>
+              <artifactId>swagger-jaxrs2</artifactId>
+              <version>${io.swagger.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>javax.ws.rs</groupId>
+              <artifactId>javax.ws.rs-api</artifactId>
+              <version>2.1.1</version>
+            </dependency>
+            <dependency>
+              <groupId>javax.servlet</groupId>
+              <artifactId>javax.servlet-api</artifactId>
+              <version>4.0.1</version>
+            </dependency>
+          </dependencies>
+          <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>resolve</goal>
+            </goals>
+          </execution>
+        </executions>
+        </plugin>
+        <plugin>
+          <!-- plugin to generate OpenAPI documentation for Spring REST Services -->
+          <groupId>io.github.kbuntrock</groupId>
+          <artifactId>openapi-maven-plugin</artifactId>
+          <version>0.0.23</version>
+          <executions>
+            <execution>
+              <phase>compile</phase>
+              <goals>
+                <goal>documentation</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <!-- plugin to merge JAXRS and Spring OpenAPI documentation -->
+          <groupId>com.rameshkp</groupId>
+          <artifactId>openapi-merger-maven-plugin</artifactId>
+          <version>1.0.5</version>
+          <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>merge</goal>
+            </goals>
+          </execution>
+        </executions>
         </plugin>
         <plugin>
           <groupId>org.jboss.maven.plugins</groupId>


### PR DESCRIPTION
Before this fix, the actual swagger plugin and configuration only create documentation for jaxrs services, but not Spring ones

This commit change the swagger plugin to have
- one plugin for Jaxrs Services
- one plugin for Spring Services
- one plugin for merge generated files

Resolves meeds-io/meeds#3557

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
